### PR TITLE
decimal scaling on CamelotRelayer

### DIFF
--- a/src/contracts/oracles/Relayer.sol
+++ b/src/contracts/oracles/Relayer.sol
@@ -16,7 +16,7 @@ contract Relayer {
   string public symbol;
 
   uint128 public baseAmount;
-  uint256 public multiplier;
+  int256 public multiplier;
   uint32 public quotePeriod;
 
   constructor(address _algebraV3Factory, address _baseToken, address _quoteToken, uint32 _quotePeriod) {
@@ -36,7 +36,7 @@ contract Relayer {
     }
 
     baseAmount = uint128(10 ** IERC20Metadata(_baseToken).decimals());
-    multiplier = 18 - IERC20Metadata(_quoteToken).decimals();
+    multiplier = int256(18) - int256(uint256(IERC20Metadata(_quoteToken).decimals()));
     quotePeriod = _quotePeriod;
 
     symbol = string(abi.encodePacked(IERC20Metadata(_baseToken).symbol(), ' / ', IERC20Metadata(_quoteToken).symbol()));
@@ -72,6 +72,18 @@ contract Relayer {
   }
 
   function _parseResult(uint256 _quoteResult) internal view returns (uint256 _result) {
-    return _quoteResult * 10 ** multiplier;
+    if (multiplier > 0) {
+      return _quoteResult * (10 ** uint256(multiplier));
+    }
+    else if (multiplier < 0) {
+      return _quoteResult / (10 ** abs(multiplier));
+    }
+    else return _quoteResult;
+  }
+
+  // @notice Return the absolute value of a signed integer as an unsigned integer
+  function abs(int256 x) internal pure returns (uint256) {
+    x >= 0 ? x : -x;
+    return uint256(x);
   }
 }

--- a/src/interfaces/oracles/IRelayer.sol
+++ b/src/interfaces/oracles/IRelayer.sol
@@ -27,7 +27,7 @@ interface IRelayer is IBaseOracle {
   /**
    * @dev The multiplier used to convert the quote into an 18 decimals format
    */
-  function multiplier() external view returns (uint256 _multiplier);
+  function multiplier() external view returns (int256 _multiplier);
 
   /**
    * @dev The length of the TWAP used to consult the pool


### PR DESCRIPTION
closes #233 [#233](https://github.com/open-dollar/od-contracts/issues/233)

Originally I had made changes to both the UniV3 relayer and the Camelot relayer but it doesn't appear that UniV3 made it into the Relayer repo.

I think we should create a new issue as well.  That's because we're currently still assuming that the base token has 18 decimals as can be seen here:

`multiplier = int256(18) - int256(uint256(IERC20Metadata(_quoteToken).decimals()));`

In reality we should be getting the `decimals()` from both tokens dynamically and calculating the multiplier without assumptions like the one made above `int256(18)`.